### PR TITLE
PHP 7.3 and nightly allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,14 @@ cache:
 php:
   - 7.1
   - 7.2
-  - 7.3
   - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: nightly
+    - php:
+        - nightly
+        - 7.3
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ cache:
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    php:
-      - nightly
-      - 7.3
+    - php: 7.3
+    - php: nightly
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php:
-        - nightly
-        - 7.3
+    php:
+      - nightly
+      - 7.3
 
 before_install:
   - composer self-update


### PR DESCRIPTION
Xenial ubuntu on travis does not yet support php 7.3. Allow it to fail!